### PR TITLE
Removes getters in favor of public member variables.

### DIFF
--- a/ChooseWHGReturnAddress.sol
+++ b/ChooseWHGReturnAddress.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.13;
 
 contract ChooseWHGReturnAddress {
 
-    mapping (address => address) returnAddresses;
+    mapping (address => address) public returnAddresses;
     uint public endDate;
 
     /// @param _endDate After this time, if `requestReturn()` has not been called
@@ -23,7 +23,7 @@ contract ChooseWHGReturnAddress {
     /// @notice This function is used to choose an address for returning the funds.
     ///  This function can only be called once, PLEASE READ THE NOTE ABOVE.
     /// @param _returnAddr The address that will receive the recued funds
-    function requestReturn(address _returnAddr) {
+    function requestReturn(address _returnAddr) external {
 
         // After the end date, the newly deployed parity multisig will be
         //  chosen if no transaction is made.
@@ -32,21 +32,6 @@ contract ChooseWHGReturnAddress {
         require(returnAddresses[msg.sender] == 0x0);
         returnAddresses[msg.sender] = _returnAddr;
         ReturnRequested(msg.sender, _returnAddr);
-    }
-    /// @notice This is a simple getter function that will be used to return the
-    ///  address that the WHG will return the funds to
-    /// @param _addr The address of the newly deployed parity multisig
-    /// @return address The chosen address that the funds will be returned to
-    function getReturnAddress(address _addr) constant returns (address) {
-        if (returnAddresses[_addr] == 0x0) {
-            return _addr;
-        } else {
-            return returnAddresses[_addr];
-        }
-    }
-
-    function isReturnRequested(address _addr) constant returns (bool) {
-        return returnAddresses[_addr] != 0x0;
     }
 
     event ReturnRequested(address indexed origin, address indexed returnAddress);

--- a/ChooseWHGReturnAddress.sol
+++ b/ChooseWHGReturnAddress.sol
@@ -23,7 +23,7 @@ contract ChooseWHGReturnAddress {
     /// @notice This function is used to choose an address for returning the funds.
     ///  This function can only be called once, PLEASE READ THE NOTE ABOVE.
     /// @param _returnAddr The address that will receive the recued funds
-    function requestReturn(address _returnAddr) external {
+    function requestReturn(address _returnAddr) external returns (bool) {
 
         // After the end date, the newly deployed parity multisig will be
         //  chosen if no transaction is made.
@@ -32,6 +32,8 @@ contract ChooseWHGReturnAddress {
         require(returnAddresses[msg.sender] == 0x0);
         returnAddresses[msg.sender] = _returnAddr;
         ReturnRequested(msg.sender, _returnAddr);
+        
+        return true;
     }
 
     event ReturnRequested(address indexed origin, address indexed returnAddress);


### PR DESCRIPTION
Also makes `requestReturn` external (it is good to be explicit about these things).

Since this contract was put together in a hurry, it is best to keep it as simple as possible, with no extra features beyond what is necessary to do its job.  In this case, the getters were unnecessary complications that could be achieve (mostly) through a language feature.  This won't do the defaulting for you, but the defaulting is just as easy to do in the calling contract/script as it is here.